### PR TITLE
Fixed compilation error

### DIFF
--- a/ImGuiTools/Source/ImGuiTools/Private/Widgets/ClassSelectorWidget.cpp
+++ b/ImGuiTools/Source/ImGuiTools/Private/Widgets/ClassSelectorWidget.cpp
@@ -4,8 +4,6 @@
 
 #include "Utils/ImGuiUtils.h"
 
-#pragma optimize ("", off)
-
 namespace ClassSelectorUtil
 {
     static bool ClassPassesNameFilter(ImGuiTools::FHierarchicalClassInfo& ClassInfo, ImGuiTextFilter& ClassNameFilter)


### PR DESCRIPTION
A compilation error appears in the Development configuration:

`Module.ImGuiTools.cpp(11): [C4426] optimization flags changed after including header, may be due to #pragma optimize()`

It's happening because of `#pragma optimize ("", off)` in _ClassSelectorWidget.cpp_